### PR TITLE
Add diagnostics to language service using new property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-gql-plugin",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "packageManager": "yarn@3.2.1",
   "license": "MIT",
   "main": "./dist/plugin.js",

--- a/src/create-error-catcher.ts
+++ b/src/create-error-catcher.ts
@@ -9,9 +9,10 @@ export type ErrorCatcher = (
   length?: number
 ) => null;
 
-export const createErrorCatcher = (logger: Logger) => {
-  const gqlDiagnosticsMap = new Map<string, ts.Diagnostic[]>();
-
+export const createErrorCatcher = (
+  pluginsDiagnostics: Map<string, ts.Diagnostic[]>,
+  logger: Logger
+) => {
   const vsCodeEnv = isVSCodeEnv();
 
   const errorCatcher: ErrorCatcher = (
@@ -42,9 +43,9 @@ export const createErrorCatcher = (logger: Logger) => {
     }
 
     if (sourceFile) {
-      const gqlDiagnostics = gqlDiagnosticsMap.get(sourceFile.fileName) ?? [];
+      const gqlDiagnostics = pluginsDiagnostics.get(sourceFile.fileName) ?? [];
 
-      gqlDiagnosticsMap.set(sourceFile.fileName, [
+      pluginsDiagnostics.set(sourceFile.fileName, [
         ...gqlDiagnostics,
         {
           category: ts.DiagnosticCategory.Error,
@@ -60,8 +61,5 @@ export const createErrorCatcher = (logger: Logger) => {
     return null;
   };
 
-  return {
-    errorCatcher,
-    gqlDiagnosticsMap,
-  };
+  return errorCatcher;
 };

--- a/src/create-language-service-proxy.ts
+++ b/src/create-language-service-proxy.ts
@@ -1,27 +1,43 @@
 import tsl from 'typescript/lib/tsserverlibrary';
 
-const expectedProperty: keyof tsl.LanguageService = 'getSemanticDiagnostics';
+const pluginsDiagnosticsProperty: keyof LanguageServiceWithDiagnostics =
+  'pluginsDiagnostics';
 
-export const createLanguageServiceProxy = (
-  languageService: tsl.LanguageService,
-  gqlDiagnosticsMap: Map<string, tsl.Diagnostic[]>
-) => {
+const getSemanticDiagnosticsProperty: keyof tsl.LanguageService =
+  'getSemanticDiagnostics';
+
+export type LanguageServiceWithDiagnostics = tsl.LanguageService & {
+  pluginsDiagnostics: Map<string, tsl.Diagnostic[]>;
+};
+
+export const createLanguageServiceWithDiagnostics = (
+  languageService: tsl.LanguageService
+): LanguageServiceWithDiagnostics => {
+  const gqlDiagnosticsMap = new Map<string, tsl.Diagnostic[]>();
+
   /**
    * Add graphql errors to diagnostics
    */
   const getSemanticDiagnostics: tsl.LanguageService['getSemanticDiagnostics'] =
     (fileName) => [
-      ...(gqlDiagnosticsMap.get(fileName) ?? []),
+      ...(proxy.pluginsDiagnostics.get(fileName) ?? []),
       ...languageService.getSemanticDiagnostics(fileName),
     ];
 
-  return new Proxy(languageService, {
+  const proxy = new Proxy(languageService as LanguageServiceWithDiagnostics, {
     get: (target, property) => {
-      if (property !== expectedProperty) {
-        return target[property as keyof tsl.LanguageService];
+      if (property === pluginsDiagnosticsProperty) {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        return target[pluginsDiagnosticsProperty] ?? gqlDiagnosticsMap;
       }
 
-      return getSemanticDiagnostics;
+      if (property === getSemanticDiagnosticsProperty) {
+        return getSemanticDiagnostics;
+      }
+
+      return target[property as keyof tsl.LanguageService];
     },
   });
+
+  return proxy;
 };

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,6 +1,6 @@
 import TSL from 'typescript/lib/tsserverlibrary';
 import { createErrorCatcher } from './create-error-catcher';
-import { createLanguageServiceProxy } from './create-language-service-proxy';
+import { createLanguageServiceWithDiagnostics } from './create-language-service-proxy';
 import { PluginConfig } from './plugin-config';
 import { createSourceUpdater } from './source-update/create-source-updater';
 import { getSnapshotSource } from './utils/get-snapshot-source';
@@ -29,11 +29,12 @@ const init = (modules: { typescript: typeof TSL }) => {
 
     logger.log(`Plugin config ${JSON.stringify(config)}`);
 
-    const { errorCatcher, gqlDiagnosticsMap } = createErrorCatcher(logger);
+    const languageServiceWithDiagnostics =
+      createLanguageServiceWithDiagnostics(languageService);
 
-    const languageServiceProxy = createLanguageServiceProxy(
-      languageService,
-      gqlDiagnosticsMap
+    const errorCatcher = createErrorCatcher(
+      languageServiceWithDiagnostics.pluginsDiagnostics,
+      logger
     );
 
     const overrideTS = objectOverride(ts);
@@ -100,7 +101,7 @@ const init = (modules: { typescript: typeof TSL }) => {
         }
     );
 
-    return languageServiceProxy;
+    return languageServiceWithDiagnostics;
   };
 
   return { create };


### PR DESCRIPTION
Use of new LanguageService type allowing to access plugins diagnostics. This add was done for `tsc-ls` package: https://github.com/Chnapy/tsc-ls/pull/1

```ts
export type LanguageServiceWithDiagnostics = tsl.LanguageService & {
  pluginsDiagnostics: Map<string, tsl.Diagnostic[]>;
};
```