### PR TITLE
Fix gql no call-expressions typing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,7 +50,7 @@ const jsRules = {
   'no-proto': ['error'],
   'no-restricted-globals': ['error'],
   'no-return-assign': ['error'],
-  'no-underscore-dangle': ['error', { allow: ['_id'] }],
+  'no-underscore-dangle': ['error', { allow: ['_id', '__apiType'] }],
   'no-unneeded-ternary': ['error'],
   'no-unused-expressions': ['error', { allowShortCircuit: true }],
   'no-useless-call': ['error'],

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Check - Example type
+        run: yarn c:type ./example
+
       - name: Publish to NPM (dry-run on PR)
         uses: JS-DevTools/npm-publish@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 !.yarn/versions
 !.yarn/unplugged
 
-/node_modules/
+**/node_modules/.cache/
 coverage/
 
 dist/

--- a/example/expect-errors.ts
+++ b/example/expect-errors.ts
@@ -1,5 +1,5 @@
-import { gql } from 'graphql-tag';
 import { useQuery } from '@apollo/client';
+import { gql } from 'graphql-tag';
 
 const { data } = useQuery(
   gql(`
@@ -19,3 +19,14 @@ console.log(
   // @ts-expect-error toto does not exist in { user, users }
   data?.toto
 );
+
+const ignored = gql`
+  query ProfileUserignored {
+    users {
+      id
+    }
+  }
+`;
+
+// @ts-expect-error gql`` should be ignored by plugin and gives DocumentNode type
+ignored.__apiType?.toString();

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,5 +1,5 @@
-import { gql } from 'graphql-tag';
 import { useQuery } from '@apollo/client';
+import { gql } from 'graphql-tag';
 
 const { data: abc } = useQuery(
   gql(`

--- a/src/source-update/create-source-updater.test.ts
+++ b/src/source-update/create-source-updater.test.ts
@@ -295,8 +295,7 @@ describe('Create source updater', () => {
       }
 
       export function gql<Literal extends keyof _unique_module_name.DocumentMap>(
-        literals: Literal | readonly string[],
-        ...args: any[]
+        literals: Literal
       ): _unique_module_name.DocumentMap[Literal];
     }
   `)
@@ -528,8 +527,7 @@ describe('Create source updater', () => {
       }
 
       export function gql<Literal extends keyof _unique_module_name.DocumentMap>(
-        literals: Literal | readonly string[],
-        ...args: any[]
+        literals: Literal
       ): _unique_module_name.DocumentMap[Literal];
     }
   `)
@@ -732,8 +730,7 @@ describe('Create source updater', () => {
       }
 
       export function gql<Literal extends keyof _unique_module_name.DocumentMap>(
-        literals: Literal | readonly string[],
-        ...args: any[]
+        literals: Literal
       ): _unique_module_name.DocumentMap[Literal];
     }
   `)

--- a/src/source-update/generate-bottom-content.ts
+++ b/src/source-update/generate-bottom-content.ts
@@ -53,8 +53,7 @@ declare module 'graphql-tag' {
   }
 
   export function gql<Literal extends keyof ${moduleName}.DocumentMap>(
-    literals: Literal | readonly string[],
-    ...args: any[]
+    literals: Literal
   ): ${moduleName}.DocumentMap[Literal];
 }
 `;


### PR DESCRIPTION
``gql`...`;`` uses typing were broken when used aside ``gql(`...`)``.

Also add example type-check into CI for type-testing.