### PR TITLE
Setup GitHub auto-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI - CD
+name: CI
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   checks:
-    name: Checks & deploy
+    name: Checks
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -37,9 +37,3 @@ jobs:
 
       - name: Check - Example type
         run: yarn c:type ./example
-
-      - name: Publish to NPM (dry-run on PR)
-        uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          dry-run: ${{ github.ref != 'refs/heads/master' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  checks:
+    name: Release to NPM
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Build
+        run: yarn build
+
+      - name: Publish to NPM - if package version changed
+        id: publish
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create new release - if published to NPM before
+        if: ${{ steps.publish.outputs.type != 'none' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.publish.outputs.version }}
+          generate_release_notes: true


### PR DESCRIPTION
Setup auto-release using `softprops/action-gh-release` github action.
Release is created after NPM package publish only. So package version should change to have new release.

Release content is generated from every merge-commits since previous release publish.

fix #17 